### PR TITLE
test : restdocs 문서화를 위한 controller 단위 테스트 추가 작성

### DIFF
--- a/src/docs/index.adoc
+++ b/src/docs/index.adoc
@@ -380,3 +380,105 @@ include::{snippets}/notice-board-controller/delete/http-request.adoc[]
 
 .Response Example
 include::{snippets}/notice-board-controller/delete/http-response.adoc[]
+
+[[Recruitment-Board-API]]
+== Recruitment Board API
+
+=== 모집 게시물 생성
+
+`POST /api/boards/recruitment`
+
+모집 게시물을 생성하는 API입니다.
+
+==== 요청
+
+include::{snippets}/recruitment-board-controller/create/request-fields.adoc[]
+
+.Request Example
+include::{snippets}/recruitment-board-controller/create/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/recruitment-board-controller/create/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/recruitment-board-controller/create/http-response.adoc[]
+
+=== 모집 게시물 수정
+
+`PATCH /api/boards/recruitment/{id}`
+
+모집 게시물을 수정하는 API입니다.
+
+==== 요청
+
+include::{snippets}/recruitment-board-controller/update/path-parameters.adoc[]
+include::{snippets}/recruitment-board-controller/update/request-fields.adoc[]
+
+.Request Example
+include::{snippets}/recruitment-board-controller/update/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/recruitment-board-controller/update/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/recruitment-board-controller/update/http-response.adoc[]
+
+=== 모집 게시물 조회
+
+`GET /api/boards/recruitment/{id}`
+
+특정 모집 게시물을 조회하는 API입니다.
+
+==== 요청
+
+include::{snippets}/recruitment-board-controller/read/path-parameters.adoc[]
+
+.Request Example
+include::{snippets}/recruitment-board-controller/read/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/recruitment-board-controller/read/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/recruitment-board-controller/read/http-response.adoc[]
+
+=== 클럽의 모든 모집 게시물 조회
+
+`GET /api/boards/recruitment/club/{clubId}`
+
+특정 클럽의 모든 모집 게시물을 조회하는 API입니다.
+
+==== 요청
+
+include::{snippets}/recruitment-board-controller/readAll/path-parameters.adoc[]
+
+.Request Example
+include::{snippets}/recruitment-board-controller/readAll/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/recruitment-board-controller/readAll/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/recruitment-board-controller/readAll/http-response.adoc[]
+
+=== 모집 게시물 삭제
+
+`DELETE /api/boards/recruitment/{id}`
+
+특정 모집 게시물을 삭제하는 API입니다.
+
+==== 요청
+
+include::{snippets}/recruitment-board-controller/delete/path-parameters.adoc[]
+
+.Request Example
+include::{snippets}/recruitment-board-controller/delete/http-request.adoc[]
+
+==== 응답
+
+.Response Example
+include::{snippets}/recruitment-board-controller/delete/http-response.adoc[]

--- a/src/docs/index.adoc
+++ b/src/docs/index.adoc
@@ -7,6 +7,62 @@
 :sectlinks:
 :snippets: C:/IntelliJProject/Club-Community_Backend/build/generated-snippets
 
+[[Mebmer-API]]
+== Mebmer API
+
+=== 회원 가입
+
+`POST /api/members/signup`
+
+회원 가입을 위한 API입니다.
+
+==== 요청
+
+include::{snippets}/member-controller/signup/request-fields.adoc[]
+
+.Request Example
+include::{snippets}/member-controller/signup/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/member-controller/signup/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/member-controller/signup/http-response.adoc[]
+
+=== 회원 정보 업데이트
+
+`PATCH /api/members/pending`
+
+회원 정보를 업데이트하는 API입니다.
+
+==== 요청
+
+include::{snippets}/member-controller/update/request-fields.adoc[]
+
+.Request Example
+include::{snippets}/member-controller/update/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/member-controller/update/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/member-controller/update/http-response.adoc[]
+
+=== 현재 로그인된 회원 정보 조회
+
+`GET /api/members/me`
+
+현재 로그인된 회원의 정보를 조회하는 API입니다.
+
+==== 응답
+
+include::{snippets}/member-controller/readMe/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/member-controller/readMe/http-response.adoc[]
+
 [[Club-API]]
 == Club API
 
@@ -120,62 +176,6 @@ include::{snippets}/club-controller-test/delete-club-member/http-request.adoc[]
 
 include::{snippets}/club-controller-test/delete-club-member/response-body.adoc[]
 
-[[Mebmer-API]]
-== Mebmer API
-
-=== 회원 가입
-
-`POST /api/members/signup`
-
-회원 가입을 위한 API입니다.
-
-==== 요청
-
-include::{snippets}/member-controller/signup/request-fields.adoc[]
-
-.Request Example
-include::{snippets}/member-controller/signup/http-request.adoc[]
-
-==== 응답
-
-include::{snippets}/member-controller/signup/response-fields.adoc[]
-
-.Response Example
-include::{snippets}/member-controller/signup/http-response.adoc[]
-
-=== 회원 정보 업데이트
-
-`PATCH /api/members/pending`
-
-회원 정보를 업데이트하는 API입니다.
-
-==== 요청
-
-include::{snippets}/member-controller/update/request-fields.adoc[]
-
-.Request Example
-include::{snippets}/member-controller/update/http-request.adoc[]
-
-==== 응답
-
-include::{snippets}/member-controller/update/response-fields.adoc[]
-
-.Response Example
-include::{snippets}/member-controller/update/http-response.adoc[]
-
-=== 현재 로그인된 회원 정보 조회
-
-`GET /api/members/me`
-
-현재 로그인된 회원의 정보를 조회하는 API입니다.
-
-==== 응답
-
-include::{snippets}/member-controller/readMe/response-fields.adoc[]
-
-.Response Example
-include::{snippets}/member-controller/readMe/http-response.adoc[]
-
 
 [[Image-Board-API]]
 == Image Board API
@@ -278,3 +278,105 @@ include::{snippets}/image-board-controller/delete/http-request.adoc[]
 
 .Response Example
 include::{snippets}/image-board-controller/delete/http-response.adoc[]
+
+[[Notice-Board-API]]
+== Notice Board API
+
+=== 공지사항 게시물 생성
+
+`POST /api/boards/notice`
+
+공지사항 게시물을 생성하는 API입니다.
+
+==== 요청
+
+include::{snippets}/notice-board-controller/create/request-fields.adoc[]
+
+.Request Example
+include::{snippets}/notice-board-controller/create/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/notice-board-controller/create/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/notice-board-controller/create/http-response.adoc[]
+
+=== 공지사항 게시물 수정
+
+`PATCH /api/boards/notice/{id}`
+
+공지사항 게시물을 수정하는 API입니다.
+
+==== 요청
+
+include::{snippets}/notice-board-controller/update/path-parameters.adoc[]
+include::{snippets}/notice-board-controller/update/request-fields.adoc[]
+
+.Request Example
+include::{snippets}/notice-board-controller/update/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/notice-board-controller/update/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/notice-board-controller/update/http-response.adoc[]
+
+=== 공지사항 게시물 조회
+
+`GET /api/boards/notice/{id}`
+
+특정 공지사항 게시물을 조회하는 API입니다.
+
+==== 요청
+
+include::{snippets}/notice-board-controller/read/path-parameters.adoc[]
+
+.Request Example
+include::{snippets}/notice-board-controller/read/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/notice-board-controller/read/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/notice-board-controller/read/http-response.adoc[]
+
+=== 클럽의 모든 공지사항 게시물 조회
+
+`GET /api/boards/notice/club/{clubId}`
+
+특정 클럽의 모든 공지사항 게시물을 조회하는 API입니다.
+
+==== 요청
+
+include::{snippets}/notice-board-controller/readAll/path-parameters.adoc[]
+
+.Request Example
+include::{snippets}/notice-board-controller/readAll/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/notice-board-controller/readAll/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/notice-board-controller/readAll/http-response.adoc[]
+
+=== 공지사항 게시물 삭제
+
+`DELETE /api/boards/notice/{id}`
+
+특정 공지사항 게시물을 삭제하는 API입니다.
+
+==== 요청
+
+include::{snippets}/notice-board-controller/delete/path-parameters.adoc[]
+
+.Request Example
+include::{snippets}/notice-board-controller/delete/http-request.adoc[]
+
+==== 응답
+
+.Response Example
+include::{snippets}/notice-board-controller/delete/http-response.adoc[]

--- a/src/docs/index.adoc
+++ b/src/docs/index.adoc
@@ -482,3 +482,105 @@ include::{snippets}/recruitment-board-controller/delete/http-request.adoc[]
 
 .Response Example
 include::{snippets}/recruitment-board-controller/delete/http-response.adoc[]
+
+[[Video-Board-API]]
+== Video Board API
+
+=== 비디오 게시물 생성
+
+`POST /api/boards/video`
+
+비디오 게시물을 생성하는 API입니다.
+
+==== 요청
+
+include::{snippets}/video-board-controller/create/request-parts.adoc[]
+
+.Request Example
+include::{snippets}/video-board-controller/create/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/video-board-controller/create/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/video-board-controller/create/http-response.adoc[]
+
+=== 비디오 게시물 수정
+
+`PATCH /api/boards/video/{id}`
+
+비디오 게시물을 수정하는 API입니다.
+
+==== 요청
+
+include::{snippets}/video-board-controller/update/path-parameters.adoc[]
+include::{snippets}/video-board-controller/update/request-parts.adoc[]
+
+.Request Example
+include::{snippets}/video-board-controller/update/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/video-board-controller/update/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/video-board-controller/update/http-response.adoc[]
+
+=== 비디오 게시물 조회
+
+`GET /api/boards/video/{id}`
+
+특정 비디오 게시물을 조회하는 API입니다.
+
+==== 요청
+
+include::{snippets}/video-board-controller/read/path-parameters.adoc[]
+
+.Request Example
+include::{snippets}/video-board-controller/read/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/video-board-controller/read/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/video-board-controller/read/http-response.adoc[]
+
+=== 클럽의 모든 비디오 게시물 조회
+
+`GET /api/boards/video/club/{clubId}`
+
+특정 클럽의 모든 비디오 게시물을 조회하는 API입니다.
+
+==== 요청
+
+include::{snippets}/video-board-controller/readAll/path-parameters.adoc[]
+
+.Request Example
+include::{snippets}/video-board-controller/readAll/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/video-board-controller/readAll/response-fields.adoc[]
+
+.Response Example
+include::{snippets}/video-board-controller/readAll/http-response.adoc[]
+
+=== 비디오 게시물 삭제
+
+`DELETE /api/boards/video/{id}`
+
+특정 비디오 게시물을 삭제하는 API입니다.
+
+==== 요청
+
+include::{snippets}/video-board-controller/delete/path-parameters.adoc[]
+
+.Request Example
+include::{snippets}/video-board-controller/delete/http-request.adoc[]
+
+==== 응답
+
+.Response Example
+include::{snippets}/video-board-controller/delete/http-response.adoc[]

--- a/src/test/java/org/webppo/clubcommunity_backend/builder/TestBuilder.java
+++ b/src/test/java/org/webppo/clubcommunity_backend/builder/TestBuilder.java
@@ -7,6 +7,9 @@ import org.webppo.clubcommunity_backend.dto.board.image.ImageBoardUpdateRequest;
 import org.webppo.clubcommunity_backend.dto.board.notice.NoticeBoardCreateRequest;
 import org.webppo.clubcommunity_backend.dto.board.notice.NoticeBoardDto;
 import org.webppo.clubcommunity_backend.dto.board.notice.NoticeBoardUpdateRequest;
+import org.webppo.clubcommunity_backend.dto.board.recruitment.RecruitmentBoardCreateRequest;
+import org.webppo.clubcommunity_backend.dto.board.recruitment.RecruitmentBoardDto;
+import org.webppo.clubcommunity_backend.dto.board.recruitment.RecruitmentBoardUpdateRequest;
 import org.webppo.clubcommunity_backend.dto.club.ClubDto;
 import org.webppo.clubcommunity_backend.dto.club.ClubUpdateRequest;
 import org.webppo.clubcommunity_backend.dto.member.MemberDto;
@@ -15,6 +18,7 @@ import org.webppo.clubcommunity_backend.dto.member.MemberUpdateRequest;
 import org.webppo.clubcommunity_backend.entity.board.image.Image;
 import org.webppo.clubcommunity_backend.entity.board.image.ImageBoard;
 import org.webppo.clubcommunity_backend.entity.board.notice.NoticeBoard;
+import org.webppo.clubcommunity_backend.entity.board.recruitment.RecruitmentBoard;
 import org.webppo.clubcommunity_backend.entity.club.Club;
 import org.webppo.clubcommunity_backend.entity.member.Member;
 import org.webppo.clubcommunity_backend.entity.member.type.RoleType;
@@ -200,6 +204,46 @@ public class TestBuilder {
 		return new NoticeBoardUpdateRequest(
 				"Updated Notice Title",
 				"Updated Notice Content"
+		);
+	}
+
+	public static RecruitmentBoard createRecruitmentBoard(Member member, Club club) {
+		return RecruitmentBoard.builder()
+				.title("Test Recruitment Title")
+				.content("Test Recruitment Content")
+				.club(club)
+				.member(member)
+				.build();
+	}
+
+	public static RecruitmentBoardDto createRecruitmentBoardDto() {
+		return new RecruitmentBoardDto(
+				1L,
+				"Test Recruitment Title",
+				"Test Recruitment Content"
+		);
+	}
+
+	public static RecruitmentBoardDto createUpdatedRecruitmentBoardDto() {
+		return new RecruitmentBoardDto(
+				1L,
+				"Updated Recruitment Title",
+				"Updated Recruitment Content"
+		);
+	}
+
+	public static RecruitmentBoardCreateRequest createRecruitmentBoardCreateRequest() {
+		return new RecruitmentBoardCreateRequest(
+				"Test Recruitment Title",
+				"Test Recruitment Content",
+				1L
+		);
+	}
+
+	public static RecruitmentBoardUpdateRequest createRecruitmentBoardUpdateRequest() {
+		return new RecruitmentBoardUpdateRequest(
+				"Updated Recruitment Title",
+				"Updated Recruitment Content"
 		);
 	}
 }

--- a/src/test/java/org/webppo/clubcommunity_backend/builder/TestBuilder.java
+++ b/src/test/java/org/webppo/clubcommunity_backend/builder/TestBuilder.java
@@ -10,6 +10,9 @@ import org.webppo.clubcommunity_backend.dto.board.notice.NoticeBoardUpdateReques
 import org.webppo.clubcommunity_backend.dto.board.recruitment.RecruitmentBoardCreateRequest;
 import org.webppo.clubcommunity_backend.dto.board.recruitment.RecruitmentBoardDto;
 import org.webppo.clubcommunity_backend.dto.board.recruitment.RecruitmentBoardUpdateRequest;
+import org.webppo.clubcommunity_backend.dto.board.video.VideoBoardCreateRequest;
+import org.webppo.clubcommunity_backend.dto.board.video.VideoBoardDto;
+import org.webppo.clubcommunity_backend.dto.board.video.VideoBoardUpdateRequest;
 import org.webppo.clubcommunity_backend.dto.club.ClubDto;
 import org.webppo.clubcommunity_backend.dto.club.ClubUpdateRequest;
 import org.webppo.clubcommunity_backend.dto.member.MemberDto;
@@ -19,6 +22,8 @@ import org.webppo.clubcommunity_backend.entity.board.image.Image;
 import org.webppo.clubcommunity_backend.entity.board.image.ImageBoard;
 import org.webppo.clubcommunity_backend.entity.board.notice.NoticeBoard;
 import org.webppo.clubcommunity_backend.entity.board.recruitment.RecruitmentBoard;
+import org.webppo.clubcommunity_backend.entity.board.video.Video;
+import org.webppo.clubcommunity_backend.entity.board.video.VideoBoard;
 import org.webppo.clubcommunity_backend.entity.club.Club;
 import org.webppo.clubcommunity_backend.entity.member.Member;
 import org.webppo.clubcommunity_backend.entity.member.type.RoleType;
@@ -244,6 +249,50 @@ public class TestBuilder {
 		return new RecruitmentBoardUpdateRequest(
 				"Updated Recruitment Title",
 				"Updated Recruitment Content"
+		);
+	}
+
+	public static VideoBoard createVideoBoard(Member member, Club club) {
+		VideoBoard videoBoard = VideoBoard.builder()
+				.title("Test Video Title")
+				.club(club)
+				.member(member)
+				.build();
+		Video video = new Video("testVideo.mp4");
+		video.setVideoBoard(videoBoard);
+		videoBoard.addVideos(List.of(video));
+		return videoBoard;
+	}
+
+	public static VideoBoardDto createVideoBoardDto() {
+		return new VideoBoardDto(
+				1L,
+				"Test Video Title",
+				List.of(new VideoBoardDto.VideoDto(1L, "testVideo.mp4", "testVideo.mp4"))
+		);
+	}
+
+	public static VideoBoardDto createUpdatedVideoBoardDto() {
+		return new VideoBoardDto(
+				1L,
+				"Updated Video Title",
+				List.of(new VideoBoardDto.VideoDto(1L, "testVideo.mp4", "testVideo.mp4"))
+		);
+	}
+
+	public static VideoBoardCreateRequest createVideoBoardCreateRequest() {
+		return new VideoBoardCreateRequest(
+				"Test Video Title",
+				1L,
+				List.of(new MockMultipartFile("videos", "video.mp4", "video/mp4", "test video".getBytes()))
+		);
+	}
+
+	public static VideoBoardUpdateRequest createVideoBoardUpdateRequest() {
+		return new VideoBoardUpdateRequest(
+				"Updated Video Title",
+				List.of(new MockMultipartFile("addedVideos", "video.mp4", "video/mp4", "test video".getBytes())),
+				List.of(1L)
 		);
 	}
 }

--- a/src/test/java/org/webppo/clubcommunity_backend/builder/TestBuilder.java
+++ b/src/test/java/org/webppo/clubcommunity_backend/builder/TestBuilder.java
@@ -4,6 +4,9 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.webppo.clubcommunity_backend.dto.board.image.ImageBoardCreateRequest;
 import org.webppo.clubcommunity_backend.dto.board.image.ImageBoardDto;
 import org.webppo.clubcommunity_backend.dto.board.image.ImageBoardUpdateRequest;
+import org.webppo.clubcommunity_backend.dto.board.notice.NoticeBoardCreateRequest;
+import org.webppo.clubcommunity_backend.dto.board.notice.NoticeBoardDto;
+import org.webppo.clubcommunity_backend.dto.board.notice.NoticeBoardUpdateRequest;
 import org.webppo.clubcommunity_backend.dto.club.ClubDto;
 import org.webppo.clubcommunity_backend.dto.club.ClubUpdateRequest;
 import org.webppo.clubcommunity_backend.dto.member.MemberDto;
@@ -11,6 +14,7 @@ import org.webppo.clubcommunity_backend.dto.member.MemberSignupRequest;
 import org.webppo.clubcommunity_backend.dto.member.MemberUpdateRequest;
 import org.webppo.clubcommunity_backend.entity.board.image.Image;
 import org.webppo.clubcommunity_backend.entity.board.image.ImageBoard;
+import org.webppo.clubcommunity_backend.entity.board.notice.NoticeBoard;
 import org.webppo.clubcommunity_backend.entity.club.Club;
 import org.webppo.clubcommunity_backend.entity.member.Member;
 import org.webppo.clubcommunity_backend.entity.member.type.RoleType;
@@ -106,6 +110,19 @@ public class TestBuilder {
 		return new ClubDto(club);
 	}
 
+	public static ClubUpdateRequest createClubUpdateRequest() {
+		return new ClubUpdateRequest(
+				"Club Name",
+				"Club Introduction",
+				"Club History",
+				new MockMultipartFile("clubPhoto", "clubPhoto.jpg", "image/jpeg", new byte[0]),
+				"Meeting Time",
+				"President",
+				"Vice President",
+				"Secretary"
+		);
+	}
+
 	public static ImageBoard createImageBoard(Member member) {
 		ImageBoard imageBoard = ImageBoard.builder()
 				.title("Test Title")
@@ -146,16 +163,43 @@ public class TestBuilder {
 		return new ImageBoardUpdateRequest("Updated Title", List.of(new MockMultipartFile("addedImages", "image.jpg", "image/jpeg", "test image".getBytes())), List.of(1L));
 	}
 
-	public static ClubUpdateRequest createClubUpdateRequest() {
-		return new ClubUpdateRequest(
-			"Club Name",
-			"Club Introduction",
-			"Club History",
-			new MockMultipartFile("clubPhoto", "clubPhoto.jpg", "image/jpeg", new byte[0]),
-			"Meeting Time",
-			"President",
-			"Vice President",
-			"Secretary"
+	public static NoticeBoard createNoticeBoard(Member member) {
+		return NoticeBoard.builder()
+				.title("Test Notice Title")
+				.content("Test Notice Content")
+				.club(createClub(member))
+				.member(member)
+				.build();
+	}
+
+	public static NoticeBoardDto createNoticeBoardDto() {
+		return new NoticeBoardDto(
+				1L,
+				"Test Notice Title",
+				"Test Notice Content"
+		);
+	}
+
+	public static NoticeBoardDto createUpdatedNoticeBoardDto() {
+		return new NoticeBoardDto(
+				1L,
+				"Updated Notice Title",
+				"Updated Notice Content"
+		);
+	}
+
+	public static NoticeBoardCreateRequest createNoticeBoardCreateRequest() {
+		return new NoticeBoardCreateRequest(
+				"Test Notice Title",
+				"Test Notice Content",
+				1L
+		);
+	}
+
+	public static NoticeBoardUpdateRequest createNoticeBoardUpdateRequest() {
+		return new NoticeBoardUpdateRequest(
+				"Updated Notice Title",
+				"Updated Notice Content"
 		);
 	}
 }

--- a/src/test/java/org/webppo/clubcommunity_backend/controller/board/NoticeBoardControllerTest.java
+++ b/src/test/java/org/webppo/clubcommunity_backend/controller/board/NoticeBoardControllerTest.java
@@ -1,0 +1,189 @@
+package org.webppo.clubcommunity_backend.controller.board;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.webppo.clubcommunity_backend.builder.TestBuilder;
+import org.webppo.clubcommunity_backend.controller.board.notice.NoticeBoardController;
+import org.webppo.clubcommunity_backend.dto.board.notice.NoticeBoardCreateRequest;
+import org.webppo.clubcommunity_backend.dto.board.notice.NoticeBoardDto;
+import org.webppo.clubcommunity_backend.dto.board.notice.NoticeBoardUpdateRequest;
+import org.webppo.clubcommunity_backend.restdocs.AbstractRestDocsTests;
+import org.webppo.clubcommunity_backend.security.PrincipalHandler;
+import org.webppo.clubcommunity_backend.service.board.notice.NoticeBoardService;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NoticeBoardController.class)
+public class NoticeBoardControllerTest extends AbstractRestDocsTests {
+
+    @MockBean
+    private NoticeBoardService noticeBoardService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void create_whenValidRequest_thenReturnNoticeBoardDto() throws Exception {
+        // Given
+        Long memberId = 1L;
+        NoticeBoardCreateRequest request = TestBuilder.createNoticeBoardCreateRequest();
+        NoticeBoardDto noticeBoardDto = TestBuilder.createNoticeBoardDto();
+        given(noticeBoardService.create(Mockito.anyLong(), Mockito.any(NoticeBoardCreateRequest.class))).willReturn(noticeBoardDto);
+
+        // When, Then
+        try (MockedStatic<PrincipalHandler> mockedPrincipalHandler = Mockito.mockStatic(PrincipalHandler.class)) {
+            mockedPrincipalHandler.when(PrincipalHandler::extractId).thenReturn(memberId);
+
+            mockMvc.perform(post("/api/boards/notice")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.title").value("Test Notice Title"))
+                    .andDo(document("notice-board-controller/create",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestFields(
+                                    fieldWithPath("title").description("게시물 제목"),
+                                    fieldWithPath("content").description("게시물 내용"),
+                                    fieldWithPath("clubId").description("클럽 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(JsonFieldType.STRING).description("성공 여부"),
+                                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("게시물 ID"),
+                                    fieldWithPath("data.title").type(JsonFieldType.STRING).description("게시물 제목"),
+                                    fieldWithPath("data.content").type(JsonFieldType.STRING).description("게시물 내용")
+                            )
+                    ));
+        }
+    }
+
+    @Test
+    void update_whenValidRequest_thenReturnUpdatedNoticeBoardDto() throws Exception {
+        // Given
+        Long memberId = 1L;
+        Long boardId = 1L;
+        NoticeBoardUpdateRequest updateRequest = TestBuilder.createNoticeBoardUpdateRequest();
+        NoticeBoardDto noticeBoardDto = TestBuilder.createUpdatedNoticeBoardDto();
+        given(noticeBoardService.update(Mockito.anyLong(), Mockito.any(NoticeBoardUpdateRequest.class))).willReturn(noticeBoardDto);
+
+        // When, Then
+        try (MockedStatic<PrincipalHandler> mockedPrincipalHandler = Mockito.mockStatic(PrincipalHandler.class)) {
+            mockedPrincipalHandler.when(PrincipalHandler::extractId).thenReturn(memberId);
+
+            mockMvc.perform(patch("/api/boards/notice/{id}", boardId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateRequest))
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.title").value("Updated Notice Title"))
+                    .andDo(document("notice-board-controller/update",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("id").description("게시물 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").description("게시물 제목"),
+                                    fieldWithPath("content").description("게시물 내용")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(JsonFieldType.STRING).description("성공 여부"),
+                                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("게시물 ID"),
+                                    fieldWithPath("data.title").type(JsonFieldType.STRING).description("게시물 제목"),
+                                    fieldWithPath("data.content").type(JsonFieldType.STRING).description("게시물 내용")
+                            )
+                    ));
+        }
+    }
+
+    @Test
+    void read_whenValidRequest_thenReturnNoticeBoardDto() throws Exception {
+        // Given
+        Long boardId = 1L;
+        NoticeBoardDto noticeBoardDto = TestBuilder.createNoticeBoardDto();
+        given(noticeBoardService.read(boardId)).willReturn(noticeBoardDto);
+
+        // When, Then
+        mockMvc.perform(get("/api/boards/notice/{id}", boardId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("Test Notice Title"))
+                .andDo(document("notice-board-controller/read",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("id").description("게시물 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.STRING).description("성공 여부"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("게시물 ID"),
+                                fieldWithPath("data.title").type(JsonFieldType.STRING).description("게시물 제목"),
+                                fieldWithPath("data.content").type(JsonFieldType.STRING).description("게시물 내용")
+                        )
+                ));
+    }
+
+    @Test
+    void readAll_whenValidRequest_thenReturnNoticeBoardDtoList() throws Exception {
+        // Given
+        Long clubId = 1L;
+        List<NoticeBoardDto> noticeBoardDtos = List.of(TestBuilder.createNoticeBoardDto());
+        given(noticeBoardService.readAll(clubId)).willReturn(noticeBoardDtos);
+
+        // When, Then
+        mockMvc.perform(get("/api/boards/notice/club/{clubId}", clubId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].title").value("Test Notice Title"))
+                .andDo(document("notice-board-controller/readAll",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("clubId").description("클럽 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.STRING).description("성공 여부"),
+                                fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("게시물 ID"),
+                                fieldWithPath("data[].title").type(JsonFieldType.STRING).description("게시물 제목"),
+                                fieldWithPath("data[].content").type(JsonFieldType.STRING).description("게시물 내용")
+                        )
+                ));
+    }
+
+    @Test
+    void delete_whenValidRequest_thenReturnVoid() throws Exception {
+        // Given
+        Long boardId = 1L;
+        willDoNothing().given(noticeBoardService).delete(boardId);
+
+        // When, Then
+        mockMvc.perform(delete("/api/boards/notice/{id}", boardId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("notice-board-controller/delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("id").description("게시물 ID")
+                        )
+                ));
+    }
+}

--- a/src/test/java/org/webppo/clubcommunity_backend/controller/board/RecruitmentBoardControllerTest.java
+++ b/src/test/java/org/webppo/clubcommunity_backend/controller/board/RecruitmentBoardControllerTest.java
@@ -1,0 +1,189 @@
+package org.webppo.clubcommunity_backend.controller.board;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.webppo.clubcommunity_backend.builder.TestBuilder;
+import org.webppo.clubcommunity_backend.controller.board.recruitment.RecruitmentBoardController;
+import org.webppo.clubcommunity_backend.dto.board.recruitment.RecruitmentBoardCreateRequest;
+import org.webppo.clubcommunity_backend.dto.board.recruitment.RecruitmentBoardDto;
+import org.webppo.clubcommunity_backend.dto.board.recruitment.RecruitmentBoardUpdateRequest;
+import org.webppo.clubcommunity_backend.restdocs.AbstractRestDocsTests;
+import org.webppo.clubcommunity_backend.security.PrincipalHandler;
+import org.webppo.clubcommunity_backend.service.board.recruitment.RecruitmentBoardService;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RecruitmentBoardController.class)
+public class RecruitmentBoardControllerTest extends AbstractRestDocsTests {
+
+    @MockBean
+    private RecruitmentBoardService recruitmentBoardService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void create_whenValidRequest_thenReturnRecruitmentBoardDto() throws Exception {
+        // Given
+        Long memberId = 1L;
+        RecruitmentBoardCreateRequest request = TestBuilder.createRecruitmentBoardCreateRequest();
+        RecruitmentBoardDto recruitmentBoardDto = TestBuilder.createRecruitmentBoardDto();
+        given(recruitmentBoardService.create(Mockito.anyLong(), Mockito.any(RecruitmentBoardCreateRequest.class))).willReturn(recruitmentBoardDto);
+
+        // When, Then
+        try (MockedStatic<PrincipalHandler> mockedPrincipalHandler = Mockito.mockStatic(PrincipalHandler.class)) {
+            mockedPrincipalHandler.when(PrincipalHandler::extractId).thenReturn(memberId);
+
+            mockMvc.perform(post("/api/boards/recruitment")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.title").value("Test Recruitment Title"))
+                    .andDo(document("recruitment-board-controller/create",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestFields(
+                                    fieldWithPath("title").description("게시물 제목"),
+                                    fieldWithPath("content").description("게시물 내용"),
+                                    fieldWithPath("clubId").description("클럽 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(JsonFieldType.STRING).description("성공 여부"),
+                                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("게시물 ID"),
+                                    fieldWithPath("data.title").type(JsonFieldType.STRING).description("게시물 제목"),
+                                    fieldWithPath("data.content").type(JsonFieldType.STRING).description("게시물 내용")
+                            )
+                    ));
+        }
+    }
+
+    @Test
+    void update_whenValidRequest_thenReturnUpdatedRecruitmentBoardDto() throws Exception {
+        // Given
+        Long memberId = 1L;
+        Long boardId = 1L;
+        RecruitmentBoardUpdateRequest updateRequest = TestBuilder.createRecruitmentBoardUpdateRequest();
+        RecruitmentBoardDto recruitmentBoardDto = TestBuilder.createUpdatedRecruitmentBoardDto();
+        given(recruitmentBoardService.update(Mockito.anyLong(), Mockito.any(RecruitmentBoardUpdateRequest.class))).willReturn(recruitmentBoardDto);
+
+        // When, Then
+        try (MockedStatic<PrincipalHandler> mockedPrincipalHandler = Mockito.mockStatic(PrincipalHandler.class)) {
+            mockedPrincipalHandler.when(PrincipalHandler::extractId).thenReturn(memberId);
+
+            mockMvc.perform(patch("/api/boards/recruitment/{id}", boardId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateRequest))
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.title").value("Updated Recruitment Title"))
+                    .andDo(document("recruitment-board-controller/update",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("id").description("게시물 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").description("게시물 제목"),
+                                    fieldWithPath("content").description("게시물 내용")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(JsonFieldType.STRING).description("성공 여부"),
+                                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("게시물 ID"),
+                                    fieldWithPath("data.title").type(JsonFieldType.STRING).description("게시물 제목"),
+                                    fieldWithPath("data.content").type(JsonFieldType.STRING).description("게시물 내용")
+                            )
+                    ));
+        }
+    }
+
+    @Test
+    void read_whenValidRequest_thenReturnRecruitmentBoardDto() throws Exception {
+        // Given
+        Long boardId = 1L;
+        RecruitmentBoardDto recruitmentBoardDto = TestBuilder.createRecruitmentBoardDto();
+        given(recruitmentBoardService.read(boardId)).willReturn(recruitmentBoardDto);
+
+        // When, Then
+        mockMvc.perform(get("/api/boards/recruitment/{id}", boardId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("Test Recruitment Title"))
+                .andDo(document("recruitment-board-controller/read",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("id").description("게시물 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.STRING).description("성공 여부"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("게시물 ID"),
+                                fieldWithPath("data.title").type(JsonFieldType.STRING).description("게시물 제목"),
+                                fieldWithPath("data.content").type(JsonFieldType.STRING).description("게시물 내용")
+                        )
+                ));
+    }
+
+    @Test
+    void readAll_whenValidRequest_thenReturnRecruitmentBoardDtoList() throws Exception {
+        // Given
+        Long clubId = 1L;
+        List<RecruitmentBoardDto> recruitmentBoardDtos = List.of(TestBuilder.createRecruitmentBoardDto());
+        given(recruitmentBoardService.readAll(clubId)).willReturn(recruitmentBoardDtos);
+
+        // When, Then
+        mockMvc.perform(get("/api/boards/recruitment/club/{clubId}", clubId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].title").value("Test Recruitment Title"))
+                .andDo(document("recruitment-board-controller/readAll",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("clubId").description("클럽 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.STRING).description("성공 여부"),
+                                fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("게시물 ID"),
+                                fieldWithPath("data[].title").type(JsonFieldType.STRING).description("게시물 제목"),
+                                fieldWithPath("data[].content").type(JsonFieldType.STRING).description("게시물 내용")
+                        )
+                ));
+    }
+
+    @Test
+    void delete_whenValidRequest_thenReturnVoid() throws Exception {
+        // Given
+        Long boardId = 1L;
+        willDoNothing().given(recruitmentBoardService).delete(boardId);
+
+        // When, Then
+        mockMvc.perform(delete("/api/boards/recruitment/{id}", boardId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("recruitment-board-controller/delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("id").description("게시물 ID")
+                        )
+                ));
+    }
+}

--- a/src/test/java/org/webppo/clubcommunity_backend/controller/board/VideoBoardControllerTest.java
+++ b/src/test/java/org/webppo/clubcommunity_backend/controller/board/VideoBoardControllerTest.java
@@ -1,0 +1,203 @@
+package org.webppo.clubcommunity_backend.controller.board;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.webppo.clubcommunity_backend.builder.TestBuilder;
+import org.webppo.clubcommunity_backend.controller.board.video.VideoBoardController;
+import org.webppo.clubcommunity_backend.dto.board.video.VideoBoardCreateRequest;
+import org.webppo.clubcommunity_backend.dto.board.video.VideoBoardDto;
+import org.webppo.clubcommunity_backend.dto.board.video.VideoBoardUpdateRequest;
+import org.webppo.clubcommunity_backend.restdocs.AbstractRestDocsTests;
+import org.webppo.clubcommunity_backend.security.PrincipalHandler;
+import org.webppo.clubcommunity_backend.service.board.video.VideoBoardService;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(VideoBoardController.class)
+public class VideoBoardControllerTest extends AbstractRestDocsTests {
+
+    @MockBean
+    private VideoBoardService videoBoardService;
+
+    @Test
+    void create_whenValidRequest_thenReturnVideoBoardDto() throws Exception {
+        // Given
+        Long memberId = 1L;
+        VideoBoardCreateRequest request = TestBuilder.createVideoBoardCreateRequest();
+        VideoBoardDto videoBoardDto = TestBuilder.createVideoBoardDto();
+        given(videoBoardService.create(Mockito.anyLong(), Mockito.any(VideoBoardCreateRequest.class))).willReturn(videoBoardDto);
+
+        // When, Then
+        try (MockedStatic<PrincipalHandler> mockedPrincipalHandler = Mockito.mockStatic(PrincipalHandler.class)) {
+            mockedPrincipalHandler.when(PrincipalHandler::extractId).thenReturn(memberId);
+
+            mockMvc.perform(multipart("/api/boards/video")
+                            .file((MockMultipartFile) request.getVideos().get(0))
+                            .param("title", request.getTitle())
+                            .param("clubId", request.getClubId().toString())
+                            .contentType(MediaType.MULTIPART_FORM_DATA)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.title").value("Test Video Title"))
+                    .andDo(document("video-board-controller/create",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestParts(
+                                    partWithName("videos").description("업로드할 비디오 파일 리스트")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(JsonFieldType.STRING).description("성공 여부"),
+                                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("게시물 ID"),
+                                    fieldWithPath("data.title").type(JsonFieldType.STRING).description("게시물 제목"),
+                                    fieldWithPath("data.images").type(JsonFieldType.ARRAY).description("비디오 리스트"),
+                                    fieldWithPath("data.images[].id").type(JsonFieldType.NUMBER).description("비디오 ID"),
+                                    fieldWithPath("data.images[].uniqueName").type(JsonFieldType.STRING).description("비디오 고유 이름"),
+                                    fieldWithPath("data.images[].originName").type(JsonFieldType.STRING).description("비디오 원본 이름")
+                            )
+                    ));
+        }
+    }
+
+    @Test
+    void update_whenValidRequest_thenReturnUpdatedVideoBoardDto() throws Exception {
+        // Given
+        Long memberId = 1L;
+        Long boardId = 1L;
+        VideoBoardUpdateRequest updateRequest = TestBuilder.createVideoBoardUpdateRequest();
+        VideoBoardDto videoBoardDto = TestBuilder.createUpdatedVideoBoardDto();
+        given(videoBoardService.update(Mockito.anyLong(), Mockito.any(VideoBoardUpdateRequest.class))).willReturn(videoBoardDto);
+
+        // When, Then
+        try (MockedStatic<PrincipalHandler> mockedPrincipalHandler = Mockito.mockStatic(PrincipalHandler.class)) {
+            mockedPrincipalHandler.when(PrincipalHandler::extractId).thenReturn(memberId);
+
+            mockMvc.perform(multipart("/api/boards/video/{id}", boardId)
+                            .file((MockMultipartFile) updateRequest.getAddedVideos().get(0))
+                            .param("title", updateRequest.getTitle())
+                            .param("deletedVideos", updateRequest.getDeletedVideos().get(0).toString())
+                            .contentType(MediaType.MULTIPART_FORM_DATA)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(request -> {
+                                request.setMethod("PATCH");
+                                return request;
+                            }))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.title").value("Updated Video Title"))
+                    .andDo(document("video-board-controller/update",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("id").description("게시물 ID")
+                            ),
+                            requestParts(
+                                    partWithName("addedVideos").description("추가할 비디오 파일 리스트")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(JsonFieldType.STRING).description("성공 여부"),
+                                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("게시물 ID"),
+                                    fieldWithPath("data.title").type(JsonFieldType.STRING).description("게시물 제목"),
+                                    fieldWithPath("data.images").type(JsonFieldType.ARRAY).description("비디오 리스트"),
+                                    fieldWithPath("data.images[].id").type(JsonFieldType.NUMBER).description("비디오 ID"),
+                                    fieldWithPath("data.images[].uniqueName").type(JsonFieldType.STRING).description("비디오 고유 이름"),
+                                    fieldWithPath("data.images[].originName").type(JsonFieldType.STRING).description("비디오 원본 이름")
+                            )
+                    ));
+        }
+    }
+
+    @Test
+    void read_whenValidRequest_thenReturnVideoBoardDto() throws Exception {
+        // Given
+        Long boardId = 1L;
+        VideoBoardDto videoBoardDto = TestBuilder.createVideoBoardDto();
+        given(videoBoardService.read(boardId)).willReturn(videoBoardDto);
+
+        // When, Then
+        mockMvc.perform(get("/api/boards/video/{id}", boardId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("Test Video Title"))
+                .andDo(document("video-board-controller/read",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("id").description("게시물 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.STRING).description("성공 여부"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("게시물 ID"),
+                                fieldWithPath("data.title").type(JsonFieldType.STRING).description("게시물 제목"),
+                                fieldWithPath("data.images").type(JsonFieldType.ARRAY).description("비디오 리스트"),
+                                fieldWithPath("data.images[].id").type(JsonFieldType.NUMBER).description("비디오 ID"),
+                                fieldWithPath("data.images[].uniqueName").type(JsonFieldType.STRING).description("비디오 고유 이름"),
+                                fieldWithPath("data.images[].originName").type(JsonFieldType.STRING).description("비디오 원본 이름")
+                        )
+                ));
+    }
+
+    @Test
+    void readAll_whenValidRequest_thenReturnVideoBoardDtoList() throws Exception {
+        // Given
+        Long clubId = 1L;
+        List<VideoBoardDto> videoBoardDtos = List.of(TestBuilder.createVideoBoardDto());
+        given(videoBoardService.readAll(clubId)).willReturn(videoBoardDtos);
+
+        // When, Then
+        mockMvc.perform(get("/api/boards/video/club/{clubId}", clubId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].title").value("Test Video Title"))
+                .andDo(document("video-board-controller/readAll",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("clubId").description("클럽 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.STRING).description("성공 여부"),
+                                fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("게시물 ID"),
+                                fieldWithPath("data[].title").type(JsonFieldType.STRING).description("게시물 제목"),
+                                fieldWithPath("data[].images").type(JsonFieldType.ARRAY).description("비디오 리스트"),
+                                fieldWithPath("data[].images[].id").type(JsonFieldType.NUMBER).description("비디오 ID"),
+                                fieldWithPath("data[].images[].uniqueName").type(JsonFieldType.STRING).description("비디오 고유 이름"),
+                                fieldWithPath("data[].images[].originName").type(JsonFieldType.STRING).description("비디오 원본 이름")
+                        )
+                ));
+    }
+
+    @Test
+    void delete_whenValidRequest_thenReturnVoid() throws Exception {
+        // Given
+        Long boardId = 1L;
+        willDoNothing().given(videoBoardService).delete(boardId);
+
+        // When, Then
+        mockMvc.perform(delete("/api/boards/video/{id}", boardId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("video-board-controller/delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("id").description("게시물 ID")
+                        )
+                ));
+    }
+}


### PR DESCRIPTION
- restdocs 문서화를 위한 NoticeBoardControllerTest 를 작성하였습니다.
- restdocs 문서화를 위한 RecruitmentBoardControllerTest 를 작성하였습니다.
- restdocs 문서화를 위한 VideoBoardControllerTest 를 작성하였습니다.

#### 참고 자료
![image](https://github.com/joon6093/Club-Community_Backend/assets/118044367/572b3889-4860-4a8e-88e6-66d6292f15c0)
